### PR TITLE
Changed URL to "Verification Techniques" material

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's great when people get excited about things, but sometimes they get a little
 
 * **Caveats:** Written in 2000 and doesn't cover modern tools/techniques, such as TLA+ or dependent typing.
 
-* **Notes:** Part of [Peter Gutmann](https://www.cs.auckland.ac.nz/~pgut001/)'s thesis, "The Design and Verification of a Cryptographic Security Architecture".
+* **Notes:** Part of [Peter Gutmann](https://www.cs.auckland.ac.nz/~pgut001/)'s thesis, "The Design and Verification of a Cryptographic Security Architecture". The whole thesis can be found [here](https://archive.org/details/springer_10.1007-b97264/mode/2up).
 
 #### [Static vs Dynamic Typing: a literature review](https://danluu.com/empirical-pl/)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It's great when people get excited about things, but sometimes they get a little _too_ excited. This an awesome (rigorous and respectful) and curated (I read every suggestion and make judgement calls) list of cold showers on overhyped topics. This does **not** mean the enthusiasm is bad or wrong: we're just reminding people to stay grounded. Feel free to submit your favorites!
 
-####  [Verification Techniques](http://www.cypherpunks.to/~peter/04_verif_techniques.pdf) (PDF)
+####  [Verification Techniques](https://archive.org/details/springer_10.1007-b97264/page/n139/mode/2up)
 
 * **Hype:** "Formal Verification is a great way to write software. We should prove all of our code correct."
 


### PR DESCRIPTION
https://www.cypherpunks.to/~peter/04_verif_techniques.pdf is no longer available; I found https://archive.org/details/springer_10.1007-b97264/page/n139/mode/2up instead.